### PR TITLE
增加 markdownEnableOnly 字段

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,8 +8,8 @@
         "no-unused-expressions": [2, { allowShortCircuit: true }],
         "no-script-url": 0,
     },
-    "globals": {
-        "$": true,
-        "template": true,
-    }
+    "env": {
+        "node": true,
+        "browser": true,
+    },
 }

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist
 /node_modules
 .sync-config.cson
 .DS_Store
+*-debug.log

--- a/README.md
+++ b/README.md
@@ -36,10 +36,15 @@ var forsythia = new Forsythia('editor', {
     markdownDisabled: ['heading', 'code', 'table', 'blockquote',
         'hr', 'list', 'link', 'autolink', 'emphasis', 'fence',
         'lheading', 'escape', 'reference', 'html_block', 'newline', 'backticks'],
+    markdownEnableOnly: [],     // options as the same like above.
 });
 ```
 
 Just by passing `markdownDisabled` option, You can easily disable some markdown rules like heading, code and so on.
+
+Meanwhile, you can also pass the `markdownEnableOnly` option, it accept an array list for the markdown syntax that you wanted to convert only.
+
+**if the option has `markdownDisabled` and `markdownEnableOnly` both, only the `markdownEnableOnly` works well.**
 
 The callBack `onAddImg` is triggerred when the user has selected a file in toolbar.
 
@@ -65,4 +70,3 @@ To get the content of the editor you can use:
 ```js
 forsythia.getContent();
 ```
-

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shanbay/forsythia",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "repository": {
     "type": "git",
     "url": "git@github.com:ShanbayFE/forsythia.git"
@@ -17,12 +17,20 @@
     "clean-webpack-plugin": "^0.1.9",
     "copy-webpack-plugin": "^2.1.3",
     "css-loader": "^0.23.1",
+    "eslint": "^3.10.2",
+    "eslint-config-airbnb": "^13.0.0",
+    "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jsx-a11y": "^2.2.3",
+    "eslint-plugin-react": "^6.7.1",
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.8.5",
     "less": "^2.6.0",
     "less-loader": "^2.2.2",
     "url-loader": "^0.5.7",
     "webpack": "^1.13.2"
+  },
+  "scripts": {
+    "build": "./node_modules/.bin/webpack -w"
   },
   "author": "wendy",
   "license": "ISC"

--- a/src/javascripts/index.js
+++ b/src/javascripts/index.js
@@ -1,23 +1,32 @@
-require('../stylesheets/index.less');
-
+/* eslint no-param-reassign: ["error", { "props": false }] */
+/* eslint max-len: ["off"] */
 import Toolbar from './toolbar';
 import utils from './utils';
+
+require('../stylesheets/index.less');
 
 class Forsythia {
     constructor(id, options) {
         this.el = document.querySelector(`#${id}`);
-        this.el.className += ' forsythia';
+        this.el.classList.add('forsythia');
 
         const defaultOptions = {
             syntax: 'markdown',
             content: '',
-            markdownDisabled: [],
-            onContentChange: () => {},
             onAddImg: () => {},
+            markdownDisabled: [],
+            markdownEnableOnly: [],
         };
+
         this.options = Object.assign({}, defaultOptions, options);
+        const markdownTagList = ['heading', 'code', 'table', 'blockquote', 'hr', 'list', 'link', 'autolink', 'emphasis', 'fence', 'lheading', 'escape', 'reference', 'html_block', 'newline', 'backticks'];
 
         this.md = window.markdownit();
+
+        if (this.options.markdownEnableOnly.length) {
+            this.options.markdownDisabled = markdownTagList.filter(lint => !(this.options.markdownEnableOnly.indexOf(lint) !== -1));
+        }
+
         this.md.disable(this.options.markdownDisabled);
 
         this.toolbar = new Toolbar(this.el, this.options);

--- a/src/javascripts/index.js
+++ b/src/javascripts/index.js
@@ -13,9 +13,10 @@ class Forsythia {
         const defaultOptions = {
             syntax: 'markdown',
             content: '',
-            onAddImg: () => {},
             markdownDisabled: [],
             markdownEnableOnly: [],
+            onAddImg: () => {},
+            onContentChange: () => {},
         };
 
         this.options = Object.assign({}, defaultOptions, options);

--- a/src/javascripts/toolbar.js
+++ b/src/javascripts/toolbar.js
@@ -40,7 +40,7 @@ class Toolbar {
 
     bindEvents() {
         const $input = this.el.querySelector('input');
-        $input.addEventListener('change', e => {
+        $input.addEventListener('change', (e) => {
             this.options.onAddImg(e.target.files[0]);
         });
     }

--- a/src/javascripts/utils.js
+++ b/src/javascripts/utils.js
@@ -3,7 +3,7 @@ const utils = {
         let node = child.parentNode;
         let deep = 0;
         while (node != null) {
-            deep++;
+            deep += 1;
             if (node === parent) {
                 return deep;
             }
@@ -12,13 +12,13 @@ const utils = {
         return false;
     },
 
-    htmlToNodes: html => {
+    htmlToNodes: (html) => {
         const template = document.createElement('template');
         template.innerHTML = html;
         return template.content.childNodes;
     },
 
-    htmlToNode: html => {
+    htmlToNode: (html) => {
         const template = document.createElement('template');
         template.innerHTML = html;
         return template.content.childNodes[0];


### PR DESCRIPTION
### 增加eslint airbnb-config 的dev依赖
如果用户没有全局安装eslint 和 airbnb的规范，编辑时报错。所以安装eslint在dev依赖。

### 修改eslint规范在某些页面
具体页面中有一些内容与eslintrc中的lint规范冲突，部分修改，或者增加注释在页面头部，保证eslintrc不会报错。

### 增加`options`中新键值`markdownEnableOnly`
该key接受一个数组，存在这个key时 `markdownDisabled` 会失效，可以指定仅需要的语法。

### 更新readme
增加新key`markdownDisabled`的readme